### PR TITLE
Removed double quotes to sed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ drush config-set system.theme default italiagov
 Edit `custom/italiagov/italiagov.info.yml`
 and change `hidden` variable to `false`
 ```
-sed "-i 's/hidden: true/hidden: false/g' custom/italiagov/italiagov.info.yml"
+sed -i 's/hidden: true/hidden: false/g' custom/italiagov/italiagov.info.yml
 ```
 
 # Manage and generate assets


### PR DESCRIPTION
Double quoting both the part of the `-i` param and the arguments throws an error since `sed` command interpret the entire double-quoted string as a single argument.